### PR TITLE
Highly increased drawing performance

### DIFF
--- a/API/Object.lua
+++ b/API/Object.lua
@@ -62,6 +62,12 @@ Draw = function(self)
 
 	self.DrawCache.NeedsDraw = false
 	local pos = self:GetPosition()
+	local c = Drawing.CurrentConstraint
+
+	if pos.X + self.Width <= c[1] or pos.Y + self.Height <= c[2] or pos.X > c[3] or pos.Y > c[4] then
+		return
+	end
+	
 	Drawing.StartCopyBuffer()
 
 	if self.ClipDrawing then


### PR DESCRIPTION
I noticed that if there were a lot of objects in a view the program would start lagging, a lot. The problem was that there was no checking if the object being drawn is inside a drawing constraint or not, thus objects were always being drawn (together with their children) no matter if they were actually visible on the screen or not. My little change just checks if the object being drawn is inside a constraint and if not then it just doesn't draw it, nor it's children. The FPS increase for me was from about 3-5 FPS to about 18-20 FPS, keeping in mind that, in ComputerCraft, 20 FPS is kind of the max.